### PR TITLE
fix: fix deployments scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To make use of the `deploy.sh` script, your build environment should be organize
 
 ```
 root
-|-- code (CURRENT DIRECTORY) -> tracking code branch of aivillage/www.git
+|-- www (CURRENT DIRECTORY) -> tracking code branch of aivillage/www.git
 |    +-- archetypes 
 |    +-- content
 |    +-- data

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,12 +6,16 @@ make
 cd ../..
 hugo
 cd ../site-assets
-git pull
-rm -rf ./*
-cp -r ../code/public/* .
-cp -r ../code/CNAME .
-git add .
-git commit -m "new deployment"
-git push
-cd ../code
-git pull
+if [ $? -ne 0 ]; then
+	echo "You don't have the ../site-assets directory"
+else
+	git pull
+	rm -rf ./*
+	cp -r ../www/public/* .
+	cp -r ../www/CNAME .
+	git add .
+	git commit -m "new deployment"
+	git push
+	cd ../www
+	git pull
+fi

--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -6,7 +6,11 @@ make
 cd ../..
 hugo
 cd ../site-assets
-rm -rf ./*
-cp -r ../code/public/* .
-cp -r ../code/CNAME .
-cd ../code
+if [ $? -ne 0 ]; then
+	echo "You don't have the ../site-assets directory"
+else
+	rm -rf ./*
+	cp -r ../www/public/* .
+	cp -r ../www/CNAME .
+	cd ../www
+fi


### PR DESCRIPTION
1) result of cd command is not checked so if there is no
   ../site-assets directory, we are purging the whole repo
   in the next command.
2) the path to the checked-out repo is named 'www' not 'code'